### PR TITLE
Fix nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,12 @@ const contacts = contactsContract({
 
 ```
 
+## Publish
+
+This library is published through TravisCI when merged to master, the version number is calculated automatically by semantic release.
+
+Just create PR's to the development branch, and once that get's merged to master the release process will do it's magic.
+
 ## Credits
 
 Made from the [`tsall/typescript-library-starter`](https://github.com/tsall/typescript-library-starter).

--- a/src/nullable.ts
+++ b/src/nullable.ts
@@ -1,6 +1,4 @@
 import { Contract } from './contract';
-import { union } from './union';
-import { nil } from './nil';
 
 /**
  * Takes a contract and returns another contract to `null` or the first contract's values.
@@ -9,4 +7,9 @@ import { nil } from './nil';
  * @param contract
  * @returns Contract to `null` or first contract's values.
  */
-export const nullable = <T> (contract: Contract<T>) => union(contract, nil);
+export const nullable = <T> (contract: Contract<T>): Contract<T | null> => (x: any) => {
+	if (x === null) {
+		return x;
+	}
+	return contract(x);
+}

--- a/src/obj.ts
+++ b/src/obj.ts
@@ -1,4 +1,5 @@
-import { contract } from './contract';
+import { contract, Contract } from './contract';
+import { ParmenidesSimpleError } from './parmenides';
 
 /**
  * Object Contract: identity function that throws an error if it is called with something but an object.
@@ -7,4 +8,9 @@ import { contract } from './contract';
  * @param x an object
  * @returns x.
  */
-export const obj = contract('object') as <T extends object> (x: T) => T;
+export const obj = <T> (x: T) => {
+	if (typeof x !== 'object' || x == null) {
+		throw new ParmenidesSimpleError('object', x);
+	}
+	return x;
+};

--- a/test/nullable.test.ts
+++ b/test/nullable.test.ts
@@ -1,4 +1,4 @@
-import { nullable, str, num } from '../src/parmenides';
+import { nullable, str, num, objOf } from '../src/parmenides';
 
 describe('`nullable` contract builder', () => {
 	it('`nullable(contract)(x)` returns `null` when it is null', () => {
@@ -18,4 +18,16 @@ describe('`nullable` contract builder', () => {
 		expect(() => nullable(num)({} as any)).toThrowError(TypeError);
 		expect(() => nullable(num)(false as any)).toThrowError(TypeError);
   });
+
+  describe('nullable(objOf)', () => {
+    const contract = nullable(objOf({
+      foo: str
+    }));
+    it('not null', () => {
+      expect(contract({foo: 'foo'})).toEqual({foo: 'foo'});
+    })
+    it('null value', () => {
+      expect(contract(null)).toBe(null);
+    })
+  })
 });

--- a/test/obj-of.test.ts
+++ b/test/obj-of.test.ts
@@ -1,4 +1,4 @@
-import { str, num, objOf, ParmenidesError } from '../src/parmenides';
+import { str, num, objOf, ParmenidesError, ParmenidesSimpleError } from '../src/parmenides';
 
 describe('`objOf` contract', () => {
 	const objContract = objOf({
@@ -138,4 +138,12 @@ describe('`objOf` contract', () => {
 			} as any)
 		).toThrowError(SyntaxError);
 	});
+
+  it('`objOf(ContractMap)(null) should throw', () => {
+      const contract = objOf({
+        foo: str
+      });
+
+      expect(() => contract(null)).toThrowError(ParmenidesSimpleError)
+  })
 });

--- a/test/obj.test.ts
+++ b/test/obj.test.ts
@@ -14,4 +14,8 @@ describe('`obj` contract', () => {
 		expect(() => obj(false as any)).toThrowError(ParmenidesSimpleError);
 		expect(() => obj(undefined as any)).toThrowError(ParmenidesSimpleError);
 	});
+
+  it('`obj(null) should throw', () => {
+		expect(() => obj(null)).toThrowError(ParmenidesSimpleError);
+  })
 });


### PR DESCRIPTION
This PR fixes a problem with `nullable(objOf)`

This should return null
```
nullable(objOf({
      foo: str
})(null)
```

But it was throwing a cannot read property foo of null.